### PR TITLE
Use correct language for serving

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ tag_dir: tags
 archive_dir: archives
 category_dir: categories
 code_dir: downloads/code
-i18n_dir: :lang
+i18n_dir: :language
 skip_render:
 
 # Writing


### PR DESCRIPTION
`:lang` during `hexo server` shows in German. Using `:language` shows in English which is the default, correct?