### PR TITLE
add "keywords" in Hexo config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@
 title: Hexo
 subtitle:
 description:
+keywords:
 author: John Doe
 language:
 timezone:


### PR DESCRIPTION
"keywords" has been added in [Hexo backend](https://github.com/hexojs/hexo/blob/master/lib/plugins/helper/open_graph.js#L41). 

But not in `config.yml`.

