### PR TITLE
fix: set default lang

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ subtitle:
 description:
 keywords:
 author: John Doe
-language:
+language: en
 timezone:
 
 # URL


### PR DESCRIPTION
the value must not be empty. this matches [the docs](https://hexo.io/docs/configuration#Site).