### PR TITLE
build: add 'hexo g' to npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "hexo-site",
   "version": "0.0.0",
   "private": true,
+  "scripts": {
+    "build": "hexo generate"
+  },
   "hexo": {
     "version": ""
   },


### PR DESCRIPTION
Deployment providers like [Zeit](https://zeit.co/docs/v2/build-step/) run their magic by detecting `build` npm script.

Closes https://github.com/hexojs/hexo/issues/3740

cc @leo