### PR TITLE
fix(config): assign empty string to string-typed variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,12 +4,12 @@
 
 # Site
 title: Hexo
-subtitle:
-description:
+subtitle: ''
+description: ''
 keywords:
 author: John Doe
 language: en
-timezone:
+timezone: ''
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
@@ -37,7 +37,7 @@ titlecase: false # Transform title into titlecase
 external_link:
   enable: true # Open external links in new tab
   field: site # Apply to the whole site
-  exclude:
+  exclude: ''
 filename_case: 0
 render_drafts: false
 post_asset_folder: false
@@ -47,7 +47,7 @@ highlight:
   enable: true
   line_number: true
   auto_detect: false
-  tab_replace:
+  tab_replace: ''
 
 # Home page setting
 # path: Root path for your blogs index page. (default = '')
@@ -95,4 +95,4 @@ theme: landscape
 # Deployment
 ## Docs: https://hexo.io/docs/deployment.html
 deploy:
-  type:
+  type: ''


### PR DESCRIPTION
To be consistent with [`default_config.js`](https://github.com/hexojs/hexo/blob/master/lib/hexo/default_config.js)