### PR TITLE
Update link to hexo deployment in hello-world.md

### DIFF
--- a/source/_posts/hello-world.md
+++ b/source/_posts/hello-world.md
@@ -35,4 +35,4 @@ More info: [Generating](https://hexo.io/docs/generating.html)
 $ hexo deploy
 ```
 
-More info: [Deployment](https://hexo.io/docs/deployment.html)
+More info: [Deployment](https://hexo.io/docs/one-command-deployment.html)


### PR DESCRIPTION
https://hexo.io/docs/deployment.html is no more!

<img width="135" alt="Screen Shot 2019-10-31 at 10 40 01 PM" src="https://user-images.githubusercontent.com/12178490/67998580-73531d00-fc2f-11e9-98de-88af208d1af1.png">

I chose the one-command deployment link as it seems like the most generic one of the three links, we could also potentially allow all three links.