### PR TITLE
chore(npm): ignore optional deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+optional=false


### PR DESCRIPTION
currently running `hexo init` would have `info "fsevents@2.1.1" is an optional dependency ...` log message appearing multiple times, which can be confusing for newcomer.

This PR is an attempt to reduce verbosity.