### PR TITLE
fix(config): set 'ignore' to ignores some files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,6 +86,10 @@ pagination_dir: page
 include:
 exclude:
 ignore:
+  # ignore themes/xxx/node_modules/
+  - "**/node_modules/**"
+  # ignore themes/xxx/.git/ and other hidden files
+  - "**/.*"
 
 # Extensions
 ## Plugins: https://hexo.io/plugins/


### PR DESCRIPTION
Related: https://github.com/hexojs/hexo-starter/pull/25 , https://github.com/hexojs/hexo/issues/3904 , https://github.com/hexojs/site/pull/1195

Set default value for `ignore`.
```yaml
ignore:
  # ignore themes/xxx/node_modules/
  - "**/node_modules/**"
  # ignore themes/xxx/.git/ and other hidden files
  - "**/.*"

```

This value is useful when you git clone a theme repo to `/themes/` .