### PR TITLE
Add _multiconfig.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ db.json
 node_modules/
 public/
 .deploy*/
+_multiconfig.yml


### PR DESCRIPTION
If more than one configuration files is set, they will be combined to _multiconfig.yml.
Because this file will been generated automatically, I think it's better to add to .gitignore to avoid conflict. 