### PR TITLE
Fixed broken docs link.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,6 @@ ignore:
 theme: landscape
 
 # Deployment
-## Docs: https://hexo.io/docs/deployment.html
+## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: ''


### PR DESCRIPTION
The link '<https://hexo.io/docs/deployment.html>' in the configuration docs is leading to a 404 page. This PR corrects the link to target <https://hexo.io/docs/one-command-deployment>.