### PR TITLE
chore: use example.com for example domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,8 +12,8 @@ language: en
 timezone: ''
 
 # URL
-## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: http://yoursite.com
+## If your site is put in a subdirectory, set url as 'http://example.com/child' and root as '/child/'
+url: http://example.com
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:


### PR DESCRIPTION
We should stop to use `yoursite.com`.
`yoursite.com` is a real company's domain.

We can use `example.com` instead of `yoursite.com`.
> https://tools.ietf.org/html/rfc2606

Thank you :)