### PR TITLE
chore: bump hexo from 6.0.0 to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "version": ""
   },
   "dependencies": {
-    "hexo": "^6.0.0",
+    "hexo": "^6.2.0",
     "hexo-generator-archive": "^1.0.0",
     "hexo-generator-category": "^1.0.0",
     "hexo-generator-index": "^2.0.0",


### PR DESCRIPTION
refs: https://github.com/hexojs/hexo/pull/4950
refs: https://github.com/hexojs/hexo/releases/tag/6.2.0

Thank you :)