### PR TITLE
Add quotations for post title

### DIFF
--- a/scaffolds/post.md
+++ b/scaffolds/post.md
@@ -1,5 +1,5 @@
 ---
-title: {{ title }}
+title: '{{ title }}'
 date: {{ date }}
 tags:
 ---


### PR DESCRIPTION
Avoiding space in post title issue.

For example:
```
hexo new "[test] test"

INFO  Validating config
FATAL Something's wrong. Maybe you can find the solution here: https://hexo.io/docs/troubleshooting.html
YAMLException: bad indentation of a mapping entry (1:15)

 1 | title: [test] test
-------------------^
 2 | date: 2022-11-28 10:39:06
 3 | categories:
    at generateError (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:183:10)
    at throwError (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:187:9)
    at readBlockMapping (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:1182:7)
    at composeNode (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:1441:12)
    at readDocument (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:1625:3)
    at loadDocuments (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:1688:5)
    at load (./node_modules/hexo/node_modules/js-yaml/lib/loader.js:1714:19)
    at ./node_modules/hexo/lib/hexo/post.js:282:63
    at tryCatcher (./node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (./node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (./node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (./node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (./node_modules/bluebird/js/release/promise.js:729:18)
    at Promise._fulfill (./node_modules/bluebird/js/release/promise.js:673:18)
    at Promise._settlePromise (./node_modules/bluebird/js/release/promise.js:617:21)
    at Promise._settlePromise0 (./node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (./node_modules/bluebird/js/release/promise.js:729:18)
    at Promise._fulfill (./node_modules/bluebird/js/release/promise.js:673:18)
    at ./node_modules/bluebird/js/release/nodeback.js:42:21
    at ./node_modules/nunjucks/src/environment.js:41:5
    at RawTask.call (./node_modules/asap/asap.js:40:19)
    at flush (./node_modules/asap/raw.js:50:29)
```
